### PR TITLE
Layout, screen text, and id changes

### DIFF
--- a/calculator.kv
+++ b/calculator.kv
@@ -1,18 +1,17 @@
 #:kivy 1.0
 
 <Calculator>:
-    spacing: 120
     orientation: 'vertical'
     Label:
         id: screen
-        text: "screen"
+        text: ""
         size_hint: 1, .25
     BoxLayout:
         id: 'button pad'
         orientation: 'vertical'
         size_hint: 1,.75
         GridLayout:
-            id: ' GridLayout'
+            id: 'upper buttons'
             size_hint:1, .8
             cols: 4
             Button:
@@ -80,7 +79,7 @@
                 text: '-'
                 on_release: root.enter_button('-')
         BoxLayout:
-            id: '= and +'
+            id: 'lower buttons'
             size_hint: 1, 1
             orientation: 'horizontal'
             size_hint: 1, .2


### PR DESCRIPTION
Removed padding property of Calculator widget, screen text now defaults
to blank, and the button area has been demarcated into "upper buttons"
and "lower buttons" by id property.